### PR TITLE
feat: add hero slider builder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import { Route, Switch, useRoute } from 'wouter';
 import Admin from './admin';
 import AdminPages from './admin/pages';
+import HeroSliderBuilder from './admin/hero-slider';
 import AdminLogin from './admin/login';
 import ProtectedAdminRoute from './ProtectedAdminRoute';
-//@ts-ignore
+// @ts-expect-error - NotFound is dynamically generated
 import { NotFound } from '@/components/NotFound';
 import DynamicPage from '@/components/DynamicPage';
 
@@ -16,6 +17,10 @@ function App() {
 
       <Route path="/admin/pages">
         <ProtectedAdminRoute component={AdminPages} />
+      </Route>
+
+      <Route path="/admin/hero-slider">
+        <ProtectedAdminRoute component={HeroSliderBuilder} />
       </Route>
 
       <Route path="/admin/login" component={AdminLogin} />
@@ -32,7 +37,7 @@ function App() {
 }
 
 function PageWrapper() {
-  const [_, params] = useRoute('/:slug*');
+  const [, params] = useRoute('/:slug*');
   const slugRaw = params?.slug ?? '';
   const slug = slugRaw === '' ? 'home' : slugRaw;
 

--- a/src/admin/components/Sidebar.tsx
+++ b/src/admin/components/Sidebar.tsx
@@ -9,8 +9,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarProvider,
-  SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { Link } from "wouter";
 import { useTranslation } from "react-i18next";
@@ -19,6 +17,7 @@ import {
   Settings,
   FileText,
   Boxes,
+  ImageIcon,
 } from "lucide-react";
 export default function AppSidebar() {
   const { t } = useTranslation();
@@ -51,6 +50,14 @@ export default function AppSidebar() {
                   <SidebarMenuButton>
                     <FileText className="h-4 w-4" />
                     <span>{t("Pages")}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </Link>
+              <Link to="/admin/hero-slider">
+                <SidebarMenuItem>
+                  <SidebarMenuButton>
+                    <ImageIcon className="h-4 w-4" />
+                    <span>Hero Slider</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               </Link>

--- a/src/admin/hero-slider.tsx
+++ b/src/admin/hero-slider.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import AppSidebar from './components/Sidebar';
+import { SidebarProvider } from '@/components/ui/sidebar';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import HeroSlider, { HeroSlide } from '@/components/HeroSlider';
+import { Plus, Trash2 } from 'lucide-react';
+
+export default function HeroSliderBuilder() {
+  const [slides, setSlides] = useState<HeroSlide[]>([]);
+
+  const addSlide = () =>
+    setSlides([
+      ...slides,
+      { image: '', heading: '', subheading: '', ctaText: '', ctaLink: '' },
+    ]);
+
+  const updateSlide = (index: number, field: keyof HeroSlide, value: string) => {
+    const next = [...slides];
+    next[index][field] = value;
+    setSlides(next);
+  };
+
+  const removeSlide = (index: number) => {
+    setSlides(slides.filter((_, i) => i !== index));
+  };
+
+  return (
+    <SidebarProvider>
+      <div className="flex">
+        <AppSidebar />
+        <main className="flex-1 p-6 space-y-6">
+          <div className="flex justify-between items-center">
+            <h1 className="text-2xl font-bold">Hero Slider Builder</h1>
+            <Button onClick={addSlide}>
+              <Plus className="h-4 w-4 mr-2" /> Add slide
+            </Button>
+          </div>
+          <div className="grid gap-6">
+          {slides.map((slide, idx) => (
+            <Card key={idx}>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Slide {idx + 1}</CardTitle>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeSlide(idx)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </CardHeader>
+              <CardContent className="grid gap-4">
+                <div className="grid gap-2">
+                  <Label htmlFor={`image-${idx}`}>Image URL</Label>
+                  <Input
+                    id={`image-${idx}`}
+                    value={slide.image}
+                    onChange={(e) => updateSlide(idx, 'image', e.target.value)}
+                    placeholder="https://example.com/hero.jpg"
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor={`heading-${idx}`}>Heading</Label>
+                  <Input
+                    id={`heading-${idx}`}
+                    value={slide.heading}
+                    onChange={(e) => updateSlide(idx, 'heading', e.target.value)}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor={`sub-${idx}`}>Subheading</Label>
+                  <Input
+                    id={`sub-${idx}`}
+                    value={slide.subheading}
+                    onChange={(e) => updateSlide(idx, 'subheading', e.target.value)}
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="grid gap-2">
+                    <Label htmlFor={`ctaText-${idx}`}>CTA Text</Label>
+                    <Input
+                      id={`ctaText-${idx}`}
+                      value={slide.ctaText}
+                      onChange={(e) => updateSlide(idx, 'ctaText', e.target.value)}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor={`ctaLink-${idx}`}>CTA Link</Label>
+                    <Input
+                      id={`ctaLink-${idx}`}
+                      value={slide.ctaLink}
+                      onChange={(e) => updateSlide(idx, 'ctaLink', e.target.value)}
+                    />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        {slides.length > 0 && (
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold">Preview</h2>
+            <HeroSlider slides={slides} />
+          </div>
+        )}
+        </main>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/src/components/HeroSlider.tsx
+++ b/src/components/HeroSlider.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+
+export interface HeroSlide {
+  image: string;
+  heading?: string;
+  subheading?: string;
+  ctaText?: string;
+  ctaLink?: string;
+}
+
+interface HeroSliderProps {
+  slides: HeroSlide[];
+  interval?: number;
+}
+
+export default function HeroSlider({ slides, interval = 5000 }: HeroSliderProps) {
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    if (slides.length <= 1) return;
+    const id = setInterval(() => {
+      setCurrent((prev) => (prev + 1) % slides.length);
+    }, interval);
+    return () => clearInterval(id);
+  }, [slides.length, interval]);
+
+  if (slides.length === 0) return null;
+
+  return (
+    <div className="relative overflow-hidden">
+      {slides.map((slide, index) => (
+        <div
+          key={index}
+          className={`absolute inset-0 transition-opacity duration-700 ${
+            index === current ? 'opacity-100' : 'opacity-0'
+          }`}
+        >
+          <img
+            src={slide.image}
+            alt={slide.heading ?? `Slide ${index + 1}`}
+            className="w-full h-96 object-cover"
+          />
+          <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center text-white p-4">
+            {slide.heading && (
+              <h2 className="text-3xl font-bold mb-2">{slide.heading}</h2>
+            )}
+            {slide.subheading && <p className="mb-4">{slide.subheading}</p>}
+            {slide.ctaText && slide.ctaLink && (
+              <a
+                href={slide.ctaLink}
+                className="bg-primary px-4 py-2 rounded"
+              >
+                {slide.ctaText}
+              </a>
+            )}
+          </div>
+        </div>
+      ))}
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex space-x-2">
+        {slides.map((_, idx) => (
+          <button
+            key={idx}
+            onClick={() => setCurrent(idx)}
+            className={`w-3 h-3 rounded-full ${
+              idx === current ? 'bg-white' : 'bg-white/50'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `HeroSlider` component for hero slides
- introduce admin hero slider builder with preview and slide management
- link hero slider builder into admin routing and sidebar

## Testing
- `npm run lint` *(fails: Fast refresh only works..., Unexpected any, etc.)*
- `npm run build` *(fails: Cannot find module '@/lib/utils' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a486bf9054832ca00e9715cc7ac304